### PR TITLE
OneDrive Integration (read-only, on-demand loading)

### DIFF
--- a/EagleViewer/Info.plist
+++ b/EagleViewer/Info.plist
@@ -12,8 +12,18 @@
 				<string>com.googleusercontent.apps.741282793927-cg37c3ps9bsbrteg3q1rntss2e2fa81d</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>msauth.com.naamiru.EagleViewer</string>
+			</array>
+		</dict>
 	</array>
 	<key>GIDClientID</key>
 	<string>741282793927-cg37c3ps9bsbrteg3q1rntss2e2fa81d.apps.googleusercontent.com</string>
+	<key>OneDriveClientID</key>
+	<string>YOUR_ONEDRIVE_CLIENT_ID</string>
 </dict>
 </plist>

--- a/EagleViewer/Models/Library.swift
+++ b/EagleViewer/Models/Library.swift
@@ -11,13 +11,15 @@ import GRDB
 enum LibrarySource: Codable, Equatable {
     case file(bookmarkData: Data)
     case gdrive(fileId: String)
+    case onedrive(itemId: String)
 
-    enum Kind: String, Codable { case file, gdrive }
+    enum Kind: String, Codable { case file, gdrive, onedrive }
 
     private struct Box: Codable {
         let kind: Kind
         let bookmarkData: Data?
         let fileId: String?
+        let oneDriveItemId: String?
     }
 
     init(from decoder: Decoder) throws {
@@ -27,6 +29,8 @@ enum LibrarySource: Codable, Equatable {
             self = .file(bookmarkData: b.bookmarkData ?? Data())
         case .gdrive:
             self = .gdrive(fileId: b.fileId ?? "")
+        case .onedrive:
+            self = .onedrive(itemId: b.oneDriveItemId ?? "")
         }
     }
 
@@ -34,9 +38,11 @@ enum LibrarySource: Codable, Equatable {
         let box: Box
         switch self {
         case .file(let bookmarkData):
-            box = Box(kind: .file, bookmarkData: bookmarkData, fileId: nil)
+            box = Box(kind: .file, bookmarkData: bookmarkData, fileId: nil, oneDriveItemId: nil)
         case .gdrive(let fileId):
-            box = Box(kind: .gdrive, bookmarkData: nil, fileId: fileId)
+            box = Box(kind: .gdrive, bookmarkData: nil, fileId: fileId, oneDriveItemId: nil)
+        case .onedrive(let itemId):
+            box = Box(kind: .onedrive, bookmarkData: nil, fileId: nil, oneDriveItemId: itemId)
         }
         try box.encode(to: encoder)
     }

--- a/EagleViewer/Services/LibraryFolderManager.swift
+++ b/EagleViewer/Services/LibraryFolderManager.swift
@@ -23,6 +23,15 @@ class LibraryFolderManager: ObservableObject {
     @Published private(set) var activeLibraryURL: URL?
     @Published private(set) var currentLibraryURL: URL?
 
+    /// The source of the current library, used for on-demand image loading decisions.
+    private(set) var currentLibrarySource: LibrarySource?
+
+    /// OneDrive root item ID for the current library (nil if not OneDrive).
+    var oneDriveRootItemId: String? {
+        if case .onedrive(let itemId) = currentLibrarySource { return itemId }
+        return nil
+    }
+
     private var currentBookmarkData: Data?
     
     // task for starting security scope resources
@@ -52,6 +61,9 @@ class LibraryFolderManager: ObservableObject {
             // Stop access to previous library if any
             discardAccess()
 
+            // Set source AFTER discardAccess (which clears it)
+            currentLibrarySource = library.source
+
             // For local storage, set virtual URL without security-scoped access
             do {
                 let localURL = try LocalImageStorageManager.shared.getLocalStorageURL(for: library.id)
@@ -76,6 +88,9 @@ class LibraryFolderManager: ObservableObject {
 
             // Stop access to previous library if any
             discardAccess()
+
+            // Set source AFTER discardAccess (which clears it)
+            currentLibrarySource = library.source
 
             // security-scoped access to Eagle library
             currentBookmarkData = bookmarkData
@@ -104,6 +119,7 @@ class LibraryFolderManager: ObservableObject {
         
         accessState = .closed
         currentBookmarkData = nil
+        currentLibrarySource = nil
         currentLibraryURL = nil
         activeLibraryURL = nil
     }

--- a/EagleViewer/Services/MetadataImportManager.swift
+++ b/EagleViewer/Services/MetadataImportManager.swift
@@ -87,8 +87,10 @@ class MetadataImportManager: ObservableObject {
 
                 source = .gdrive(service: service, fileId: fileId)
             case .onedrive(let itemId):
-                let accessToken = try await OneDriveAuthManager.ensureSignedIn()
-                source = .onedrive(accessToken: accessToken, itemId: itemId)
+                // Verify user is signed in before starting import.
+                // OneDriveSourceEntity handles token refresh internally via getValidAccessToken().
+                _ = try await OneDriveAuthManager.ensureSignedIn()
+                source = .onedrive(itemId: itemId)
             }
             
             // Ensure security-scoped resource is released when task of local library ends

--- a/EagleViewer/Services/MetadataImportManager.swift
+++ b/EagleViewer/Services/MetadataImportManager.swift
@@ -80,12 +80,15 @@ class MetadataImportManager: ObservableObject {
                 }
             case .gdrive(let fileId):
                 let user = try await GoogleAuthManager.ensureSignedIn()
-                
+
                 let service = GTLRDriveService()
                 service.authorizer = user.fetcherAuthorizer
                 service.shouldFetchNextPages = true
-                
+
                 source = .gdrive(service: service, fileId: fileId)
+            case .onedrive(let itemId):
+                let accessToken = try await OneDriveAuthManager.ensureSignedIn()
+                source = .onedrive(accessToken: accessToken, itemId: itemId)
             }
             
             // Ensure security-scoped resource is released when task of local library ends

--- a/EagleViewer/Services/MetadataImporter.swift
+++ b/EagleViewer/Services/MetadataImporter.swift
@@ -14,6 +14,7 @@ struct MetadataImporter {
     enum Source {
         case url(url: URL)
         case gdrive(service: GTLRDriveService, fileId: String)
+        case onedrive(accessToken: String, itemId: String)
     }
 
     struct MetadataJSON: Decodable {
@@ -633,6 +634,8 @@ func createRootSourceEntity(_ source: MetadataImporter.Source) -> any SourceEnti
         return URLSourceEntity(url: url)
     case .gdrive(let service, let fileId):
         return GoogleDriveSourceEntity(service: service, fileId: fileId)
+    case .onedrive(let accessToken, let itemId):
+        return OneDriveSourceEntity(accessToken: accessToken, itemId: itemId)
     }
 }
 

--- a/EagleViewer/Services/OneDriveAuthManager.swift
+++ b/EagleViewer/Services/OneDriveAuthManager.swift
@@ -1,0 +1,342 @@
+//
+//  OneDriveAuthManager.swift
+//  EagleViewer
+//
+//  Created on 2025/10/01
+//
+
+import AuthenticationServices
+import CryptoKit
+import Foundation
+import OSLog
+import UIKit
+
+enum OneDriveAuthError: LocalizedError {
+    case noPresentingViewController
+    case authFailed(String)
+    case tokenExchangeFailed(String)
+    case noRefreshToken
+    case notSignedIn
+
+    var errorDescription: String? {
+        switch self {
+        case .noPresentingViewController:
+            return "Cannot present sign-in screen"
+        case .authFailed(let message):
+            return "Authentication failed: \(message)"
+        case .tokenExchangeFailed(let message):
+            return "Token exchange failed: \(message)"
+        case .noRefreshToken:
+            return "No refresh token available. Please sign in again."
+        case .notSignedIn:
+            return "Not signed in to OneDrive"
+        }
+    }
+}
+
+enum OneDriveAuthManager {
+    // MARK: - Configuration
+
+    // Placeholder client ID — user must register an Azure AD app and replace this
+    static let clientID = Bundle.main.object(forInfoDictionaryKey: "OneDriveClientID") as? String ?? ""
+    static let redirectURI = "msauth.\(Bundle.main.bundleIdentifier ?? "")://auth"
+    static let scopes = "Files.Read Files.Read.All offline_access"
+    static let tenant = "consumers" // Personal Microsoft accounts only
+
+    private static let authorizeURL = "https://login.microsoftonline.com/\(tenant)/oauth2/v2.0/authorize"
+    private static let tokenURL = "https://login.microsoftonline.com/\(tenant)/oauth2/v2.0/token"
+
+    // Keychain keys
+    private static let keychainServiceAccessToken = "com.eagleviewer.onedrive.accessToken"
+    private static let keychainServiceRefreshToken = "com.eagleviewer.onedrive.refreshToken"
+    private static let keychainServiceExpiration = "com.eagleviewer.onedrive.expiration"
+
+    // In-memory cache
+    private static var cachedAccessToken: String?
+    private static var cachedExpiration: Date?
+
+    // Retain active session to prevent deallocation during auth flow
+    private static var activeSession: ASWebAuthenticationSession?
+
+    // MARK: - Public API
+
+    /// Returns a valid access token, refreshing if needed, or prompting sign-in if no session exists.
+    @MainActor
+    static func ensureSignedIn() async throws -> String {
+        // Try cached token
+        if let token = cachedAccessToken, let exp = cachedExpiration, exp > Date().addingTimeInterval(60) {
+            return token
+        }
+
+        // Try stored token
+        if let token = keychainRead(service: keychainServiceAccessToken),
+           let expStr = keychainRead(service: keychainServiceExpiration),
+           let expInterval = TimeInterval(expStr)
+        {
+            let expDate = Date(timeIntervalSince1970: expInterval)
+            if expDate > Date().addingTimeInterval(60) {
+                cachedAccessToken = token
+                cachedExpiration = expDate
+                return token
+            }
+        }
+
+        // Try refresh
+        if let refreshToken = keychainRead(service: keychainServiceRefreshToken) {
+            do {
+                let token = try await refreshAccessToken(refreshToken)
+                return token
+            } catch {
+                Logger.app.warning("OneDrive token refresh failed, will re-authenticate: \(error)")
+            }
+        }
+
+        // Full sign-in
+        return try await performSignIn()
+    }
+
+    static func isSignedIn() -> Bool {
+        // Check for refresh token existence as the durable indicator
+        return keychainRead(service: keychainServiceRefreshToken) != nil
+    }
+
+    static func signOut() {
+        cachedAccessToken = nil
+        cachedExpiration = nil
+        keychainDelete(service: keychainServiceAccessToken)
+        keychainDelete(service: keychainServiceRefreshToken)
+        keychainDelete(service: keychainServiceExpiration)
+    }
+
+    // MARK: - OAuth Flow
+
+    @MainActor
+    private static func performSignIn() async throws -> String {
+        guard let presenting = ViewControllerGetter.getRootViewController() else {
+            throw OneDriveAuthError.noPresentingViewController
+        }
+
+        // Generate PKCE pair
+        let codeVerifier = generateCodeVerifier()
+        let codeChallenge = generateCodeChallenge(from: codeVerifier)
+        let state = UUID().uuidString
+
+        // Build authorization URL
+        var components = URLComponents(string: authorizeURL)!
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: scopes),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "prompt", value: "select_account"),
+        ]
+
+        guard let authURL = components.url else {
+            throw OneDriveAuthError.authFailed("Invalid authorization URL")
+        }
+
+        // Extract callback scheme from redirect URI
+        let callbackScheme = redirectURI.components(separatedBy: "://").first ?? ""
+
+        // Present ASWebAuthenticationSession
+        // Hold references to prevent deallocation during auth flow
+        let contextProvider = PresentationContextProvider(anchor: presenting.view.window!)
+        let callbackURL: URL = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<URL, Error>) in
+            let session = ASWebAuthenticationSession(
+                url: authURL,
+                callbackURLScheme: callbackScheme
+            ) { callbackURL, error in
+                if let error {
+                    cont.resume(throwing: OneDriveAuthError.authFailed(error.localizedDescription))
+                    return
+                }
+                guard let callbackURL else {
+                    cont.resume(throwing: OneDriveAuthError.authFailed("No callback URL received"))
+                    return
+                }
+                cont.resume(returning: callbackURL)
+            }
+            session.prefersEphemeralWebBrowserSession = false
+            session.presentationContextProvider = contextProvider
+            activeSession = session
+            session.start()
+        }
+        activeSession = nil
+
+        // Extract authorization code
+        guard let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
+              let code = components.queryItems?.first(where: { $0.name == "code" })?.value
+        else {
+            let errorDesc = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "error_description" })?.value
+            throw OneDriveAuthError.authFailed(errorDesc ?? "No authorization code in callback")
+        }
+
+        // Verify state
+        let returnedState = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "state" })?.value
+        guard returnedState == state else {
+            throw OneDriveAuthError.authFailed("State mismatch — possible CSRF attack")
+        }
+
+        // Exchange code for tokens
+        return try await exchangeCodeForTokens(code: code, codeVerifier: codeVerifier)
+    }
+
+    private static func exchangeCodeForTokens(code: String, codeVerifier: String) async throws -> String {
+        var request = URLRequest(url: URL(string: tokenURL)!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        let body = [
+            "client_id": clientID,
+            "code": code,
+            "redirect_uri": redirectURI,
+            "grant_type": "authorization_code",
+            "code_verifier": codeVerifier,
+            "scope": scopes,
+        ]
+        request.httpBody = body.map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
+            .joined(separator: "&")
+            .data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw OneDriveAuthError.tokenExchangeFailed(errorBody)
+        }
+
+        return try processTokenResponse(data)
+    }
+
+    private static func refreshAccessToken(_ refreshToken: String) async throws -> String {
+        var request = URLRequest(url: URL(string: tokenURL)!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        let body = [
+            "client_id": clientID,
+            "refresh_token": refreshToken,
+            "grant_type": "refresh_token",
+            "scope": scopes,
+        ]
+        request.httpBody = body.map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
+            .joined(separator: "&")
+            .data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            // Refresh failed — clear tokens so next call triggers full sign-in
+            signOut()
+            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw OneDriveAuthError.tokenExchangeFailed(errorBody)
+        }
+
+        return try processTokenResponse(data)
+    }
+
+    private static func processTokenResponse(_ data: Data) throws -> String {
+        struct TokenResponse: Decodable {
+            let access_token: String
+            let refresh_token: String?
+            let expires_in: Int
+        }
+
+        let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
+
+        let expiration = Date().addingTimeInterval(TimeInterval(tokenResponse.expires_in))
+
+        // Store tokens
+        keychainWrite(service: keychainServiceAccessToken, data: tokenResponse.access_token)
+        keychainWrite(service: keychainServiceExpiration, data: String(expiration.timeIntervalSince1970))
+
+        if let refreshToken = tokenResponse.refresh_token {
+            keychainWrite(service: keychainServiceRefreshToken, data: refreshToken)
+        }
+
+        // Cache
+        cachedAccessToken = tokenResponse.access_token
+        cachedExpiration = expiration
+
+        return tokenResponse.access_token
+    }
+
+    // MARK: - PKCE
+
+    private static func generateCodeVerifier() -> String {
+        var buffer = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, buffer.count, &buffer)
+        return Data(buffer).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func generateCodeChallenge(from verifier: String) -> String {
+        let data = Data(verifier.utf8)
+        let hash = SHA256.hash(data: data)
+        return Data(hash).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    // MARK: - Keychain Helpers
+
+    private static func keychainWrite(service: String, data: String) {
+        let dataBytes = Data(data.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: "onedrive",
+        ]
+        SecItemDelete(query as CFDictionary)
+
+        var addQuery = query
+        addQuery[kSecValueData as String] = dataBytes
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    private static func keychainRead(service: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: "onedrive",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func keychainDelete(service: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: "onedrive",
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+// MARK: - ASWebAuthenticationSession Presentation Context
+
+private final class PresentationContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private let anchor: ASPresentationAnchor
+
+    init(anchor: ASPresentationAnchor) {
+        self.anchor = anchor
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        anchor
+    }
+}

--- a/EagleViewer/Services/OneDriveImageDownloader.swift
+++ b/EagleViewer/Services/OneDriveImageDownloader.swift
@@ -1,0 +1,64 @@
+//
+//  OneDriveImageDownloader.swift
+//  EagleViewer
+//
+//  On-demand image downloader for OneDrive libraries.
+//  Downloads images lazily when the UI needs them, instead of during import.
+//
+
+import Foundation
+import OSLog
+
+actor OneDriveImageDownloader {
+    static let shared = OneDriveImageDownloader()
+
+    /// Tracks in-flight downloads to deduplicate concurrent requests for the same path.
+    private var inFlight: [String: Task<URL?, Error>] = [:]
+
+    /// Downloads an image from OneDrive to local storage if it doesn't already exist.
+    /// Returns the local file URL, or nil if download fails.
+    ///
+    /// - Parameters:
+    ///   - rootItemId: The OneDrive item ID of the library root folder
+    ///   - relativePath: The relative path within the library (e.g. "images/ABC.info/photo.jpg")
+    ///   - localBaseURL: The local storage base URL (e.g. Application Support/LocalImages/{id}/)
+    func ensureImageExists(
+        rootItemId: String,
+        relativePath: String,
+        localBaseURL: URL
+    ) async -> URL? {
+        let localURL = localBaseURL.appending(path: relativePath, directoryHint: .notDirectory)
+
+        // Already downloaded
+        if FileManager.default.fileExists(atPath: localURL.path) {
+            return localURL
+        }
+
+        // Check if already downloading
+        if let existing = inFlight[relativePath] {
+            return try? await existing.value
+        }
+
+        // Start download
+        let task = Task<URL?, Error> {
+            do {
+                let sourceEntity = OneDriveSourceEntity(itemId: rootItemId)
+                let fileEntity = try await sourceEntity.appending(relativePath, isFolder: false)
+                try await fileEntity.copy(to: localURL)
+                Logger.app.debug("OneDrive downloaded: \(relativePath)")
+                return localURL
+            } catch {
+                Logger.app.warning("OneDrive download failed for \(relativePath): \(error)")
+                return nil
+            }
+        }
+
+        inFlight[relativePath] = task
+        let result = try? await task.value
+
+        // Clean up in-flight tracker
+        inFlight.removeValue(forKey: relativePath)
+
+        return result
+    }
+}

--- a/EagleViewer/Services/OneDriveSourceEntity.swift
+++ b/EagleViewer/Services/OneDriveSourceEntity.swift
@@ -1,0 +1,135 @@
+//
+//  OneDriveSourceEntity.swift
+//  EagleViewer
+//
+//  Created on 2025/10/01
+//
+
+import Foundation
+
+struct OneDriveSourceEntity: SourceEntity {
+    let accessToken: String
+    let itemId: String
+
+    private static let graphBaseURL = "https://graph.microsoft.com/v1.0"
+
+    func appending(_ path: String, isFolder: Bool) async throws -> SourceEntity {
+        var currentId = itemId
+        for name in path.split(separator: "/") {
+            currentId = try await getChildItemId(parentId: currentId, childName: String(name))
+        }
+        return OneDriveSourceEntity(accessToken: accessToken, itemId: currentId)
+    }
+
+    func getData() async throws -> Data {
+        // GET /me/drive/items/{itemId}/content returns 302 redirect to download URL
+        let url = URL(string: "\(Self.graphBaseURL)/me/drive/items/\(itemId)/content")!
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+            throw SourceEntityError.fileNotFound
+        }
+
+        return data
+    }
+
+    func contentsOfFolder() async throws -> [(String, SourceEntity)] {
+        var allItems: [(String, SourceEntity)] = []
+        var nextURL: URL? = URL(string: "\(Self.graphBaseURL)/me/drive/items/\(itemId)/children?$select=id,name&$top=200")
+
+        while let url = nextURL {
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                throw SourceEntityError.fileNotFound
+            }
+
+            let result = try JSONDecoder().decode(DriveChildrenResponse.self, from: data)
+
+            let items = result.value.map { child in
+                (
+                    child.name,
+                    OneDriveSourceEntity(accessToken: accessToken, itemId: child.id) as SourceEntity
+                )
+            }
+            allItems.append(contentsOf: items)
+
+            if let next = result.nextLink {
+                nextURL = URL(string: next)
+            } else {
+                nextURL = nil
+            }
+        }
+
+        return allItems
+    }
+
+    func copy(to destination: URL) async throws {
+        // Download file content directly to destination URL
+        let url = URL(string: "\(Self.graphBaseURL)/me/drive/items/\(itemId)/content")!
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        let (tempURL, response) = try await URLSession.shared.download(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw SourceEntityError.fileNotFound
+        }
+
+        // Move downloaded file to destination
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: tempURL, to: destination)
+    }
+
+    // MARK: - Helpers
+
+    private func getChildItemId(parentId: String, childName: String) async throws -> String {
+        // URL-encode the child name for the path
+        guard let encodedName = childName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            throw SourceEntityError.fileNotFound
+        }
+
+        let url = URL(string: "\(Self.graphBaseURL)/me/drive/items/\(parentId):/\(encodedName)")!
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+            throw SourceEntityError.fileNotFound
+        }
+
+        let item = try JSONDecoder().decode(DriveItem.self, from: data)
+        return item.id
+    }
+}
+
+// MARK: - Graph API Response Models
+
+private struct DriveChildrenResponse: Decodable {
+    let value: [DriveChildItem]
+    let nextLink: String?
+
+    enum CodingKeys: String, CodingKey {
+        case value
+        case nextLink = "@odata.nextLink"
+    }
+}
+
+private struct DriveChildItem: Decodable {
+    let id: String
+    let name: String
+}
+
+private struct DriveItem: Decodable {
+    let id: String
+}

--- a/EagleViewer/Views/FirstLaunchView.swift
+++ b/EagleViewer/Views/FirstLaunchView.swift
@@ -24,7 +24,7 @@ struct FirstLaunchView: View {
                 switch source {
                 case .file(let bookmarkData):
                     path.append(.option(name, bookmarkData))
-                case .gdrive:
+                case .gdrive, .onedrive:
                     Task {
                         try? await createCloudLibrary(name: name, source: source)
                     }

--- a/EagleViewer/Views/ItemImageView.swift
+++ b/EagleViewer/Views/ItemImageView.swift
@@ -1,5 +1,5 @@
 //
-//  ItemThumbnailView.swift
+//  ItemImageView.swift
 //  EagleViewer
 //
 //  Created on 2025/08/24
@@ -12,50 +12,86 @@ struct ItemImageView: View {
     let item: Item
     let isSelected: Bool
     @EnvironmentObject private var libraryFolderManager: LibraryFolderManager
-    
-    private var imageURL: URL? {
+    @State private var resolvedURL: URL?
+    @State private var downloadAttempted = false
+
+    private var localImageURL: URL? {
         guard let currentLibraryURL = libraryFolderManager.currentLibraryURL else {
             return nil
         }
-        
         return currentLibraryURL.appending(path: item.imagePath, directoryHint: .notDirectory)
     }
-    
+
+    private var isOneDrive: Bool {
+        libraryFolderManager.oneDriveRootItemId != nil
+    }
+
     private var placeholder: some View {
         Rectangle().fill(Color.gray.opacity(0.3))
             .aspectRatio(CGSize(width: item.width, height: item.height), contentMode: .fit)
     }
-    
+
     private var loader: some View {
         Rectangle().fill(Color.clear)
             .aspectRatio(CGSize(width: item.width, height: item.height), contentMode: .fit)
     }
-    
-    var body: some View {
-        if let imageURL {
-            LazyImage(url: imageURL) { state in
-                if let image = state.image {
-                    if item.imagePath.lowercased().hasSuffix(".gif")
-                        || item.imagePath.lowercased().hasSuffix(".webp")
-                    {
-                        AnimatedImageView(
-                            url: imageURL,
-                            contentMode: .scaleAspectFit,
-                            shouldAnimate: isSelected
-                        )
-                    } else {
-                        image
-                            .resizable()
-                            .aspectRatio(CGSize(width: item.width, height: item.height), contentMode: .fit)
-                    }
-                } else if state.error != nil {
-                    placeholder
+
+    @ViewBuilder
+    private func imageContent(url: URL) -> some View {
+        LazyImage(url: url) { state in
+            if let image = state.image {
+                if item.imagePath.lowercased().hasSuffix(".gif")
+                    || item.imagePath.lowercased().hasSuffix(".webp")
+                {
+                    AnimatedImageView(
+                        url: url,
+                        contentMode: .scaleAspectFit,
+                        shouldAnimate: isSelected
+                    )
                 } else {
-                    loader
+                    image
+                        .resizable()
+                        .aspectRatio(CGSize(width: item.width, height: item.height), contentMode: .fit)
                 }
+            } else if state.error != nil {
+                placeholder
+            } else {
+                loader
             }
+        }
+    }
+
+    var body: some View {
+        if let url = resolvedURL {
+            imageContent(url: url)
+        } else if isOneDrive {
+            // OneDrive lazy loading: show loader while downloading
+            loader
+                .task {
+                    guard !downloadAttempted else { return }
+                    downloadAttempted = true
+                    await downloadOnDemand()
+                }
+        } else if let imageURL = localImageURL {
+            imageContent(url: imageURL)
         } else {
             placeholder
+        }
+    }
+
+    private func downloadOnDemand() async {
+        guard let rootItemId = libraryFolderManager.oneDriveRootItemId,
+              let baseURL = libraryFolderManager.currentLibraryURL
+        else { return }
+
+        let url = await OneDriveImageDownloader.shared.ensureImageExists(
+            rootItemId: rootItemId,
+            relativePath: item.imagePath,
+            localBaseURL: baseURL
+        )
+
+        await MainActor.run {
+            resolvedURL = url
         }
     }
 }

--- a/EagleViewer/Views/ItemVideoView.swift
+++ b/EagleViewer/Views/ItemVideoView.swift
@@ -1,5 +1,5 @@
 //
-//  ItemThumbnailView.swift
+//  ItemVideoView.swift
 //  EagleViewer
 //
 //  Created on 2025/08/24
@@ -12,28 +12,33 @@ struct ItemVideoView: View {
     static func isVideo(item: Item) -> Bool {
         return item.duration != 0
     }
-        
+
     let item: Item
     let dismiss: () -> Void
-    
+
     @State private var player: AVPlayer?
-    
+    @State private var resolvedURL: URL?
+    @State private var downloadAttempted = false
+
     @EnvironmentObject private var imageViewerManager: ImageViewerManager
     @EnvironmentObject private var libraryFolderManager: LibraryFolderManager
-    
-    private var videoURL: URL? {
+
+    private var localVideoURL: URL? {
         guard let currentLibraryURL = libraryFolderManager.currentLibraryURL else {
             return nil
         }
-        
         return currentLibraryURL.appending(path: item.imagePath, directoryHint: .notDirectory)
     }
-    
+
+    private var isOneDrive: Bool {
+        libraryFolderManager.oneDriveRootItemId != nil
+    }
+
     private var placeholder: some View {
         Rectangle().fill(Color.gray.opacity(0.3))
             .aspectRatio(CGSize(width: item.width, height: item.height), contentMode: .fit)
     }
-    
+
     var body: some View {
         Group {
             if let player {
@@ -62,13 +67,34 @@ struct ItemVideoView: View {
             }
         }
         .ignoresSafeArea()
-        .onAppear {
-            if let videoURL {
-                player = AVPlayer(url: videoURL)
+        .task {
+            if isOneDrive {
+                guard !downloadAttempted else { return }
+                downloadAttempted = true
+                await downloadOnDemand()
+            } else if let localVideoURL {
+                player = AVPlayer(url: localVideoURL)
             }
         }
     }
-    
+
+    private func downloadOnDemand() async {
+        guard let rootItemId = libraryFolderManager.oneDriveRootItemId,
+              let baseURL = libraryFolderManager.currentLibraryURL
+        else { return }
+
+        if let url = await OneDriveImageDownloader.shared.ensureImageExists(
+            rootItemId: rootItemId,
+            relativePath: item.imagePath,
+            localBaseURL: baseURL
+        ) {
+            await MainActor.run {
+                resolvedURL = url
+                player = AVPlayer(url: url)
+            }
+        }
+    }
+
     private func dragCloseGesture() -> some Gesture {
         DragGesture()
             .onEnded { value in

--- a/EagleViewer/Views/Library/LibraryAddView.swift
+++ b/EagleViewer/Views/Library/LibraryAddView.swift
@@ -55,6 +55,9 @@ struct LibraryAddView: View {
                         if case .gdrive = source {
                             self.useLocalStorage = true
                         }
+                        if case .onedrive = source {
+                            self.useLocalStorage = true
+                        }
 
                         // Pop back to root
                         path = NavigationPath()
@@ -100,9 +103,10 @@ struct LibraryAddView: View {
     }
 
     private var isCloudSource: Bool {
-        if case .gdrive = librarySource {
+        switch librarySource {
+        case .gdrive, .onedrive:
             true
-        } else {
+        default:
             false
         }
     }

--- a/EagleViewer/Views/Library/OneDriveFolderPickerView.swift
+++ b/EagleViewer/Views/Library/OneDriveFolderPickerView.swift
@@ -1,0 +1,259 @@
+//
+//  OneDriveFolderPickerView.swift
+//  EagleViewer
+//
+//  Created on 2025/10/01
+//
+
+import SwiftUI
+
+// MARK: - Model
+
+struct OneDriveItem: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let isFolder: Bool
+    let modifiedTime: Date?
+}
+
+// MARK: - OneDrive Client
+
+final class OneDriveClient {
+    private let accessToken: String
+    private static let graphBaseURL = "https://graph.microsoft.com/v1.0"
+
+    init(accessToken: String) {
+        self.accessToken = accessToken
+    }
+
+    func listChildren(of itemId: String) async throws -> [OneDriveItem] {
+        let urlString: String
+        if itemId == "root" {
+            urlString = "\(Self.graphBaseURL)/me/drive/root/children?$select=id,name,folder,lastModifiedDateTime&$top=200&$orderby=name"
+        } else {
+            urlString = "\(Self.graphBaseURL)/me/drive/items/\(itemId)/children?$select=id,name,folder,lastModifiedDateTime&$top=200&$orderby=name"
+        }
+
+        var allItems: [OneDriveItem] = []
+        var nextURL: URL? = URL(string: urlString)
+
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        while let url = nextURL {
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                throw NSError(domain: "OneDrive", code: httpResponse.statusCode, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to list folder contents (HTTP \(httpResponse.statusCode))"
+                ])
+            }
+
+            let result = try JSONDecoder().decode(ListChildrenResponse.self, from: data)
+
+            let items = result.value.map { child in
+                OneDriveItem(
+                    id: child.id,
+                    name: child.name,
+                    isFolder: child.folder != nil,
+                    modifiedTime: child.lastModifiedDateTime.flatMap { dateFormatter.date(from: $0) }
+                )
+            }
+            allItems.append(contentsOf: items)
+
+            if let next = result.nextLink {
+                nextURL = URL(string: next)
+            } else {
+                nextURL = nil
+            }
+        }
+
+        // Sort: folders first, then by name
+        return allItems.sorted {
+            if $0.isFolder != $1.isFolder { return $0.isFolder && !$1.isFolder }
+            return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+    }
+}
+
+// MARK: - Response Models
+
+private struct ListChildrenResponse: Decodable {
+    let value: [ListChildrenItem]
+    let nextLink: String?
+
+    enum CodingKeys: String, CodingKey {
+        case value
+        case nextLink = "@odata.nextLink"
+    }
+}
+
+private struct ListChildrenItem: Decodable {
+    let id: String
+    let name: String
+    let folder: FolderFacet?
+    let lastModifiedDateTime: String?
+}
+
+private struct FolderFacet: Decodable {
+    let childCount: Int?
+}
+
+// MARK: - SwiftUI View
+
+struct OneDriveFolderPickerView: View {
+    let onSelect: (String, String) -> Void // Returns (libraryName, itemId)
+    @State private var client: OneDriveClient
+    @State private var path: [OneDriveItem] = []
+
+    private let rootFolder = OneDriveItem(id: "root", name: String(localized: "OneDrive"), isFolder: true, modifiedTime: nil)
+
+    init(accessToken: String, onSelect: @escaping (String, String) -> Void) {
+        self.onSelect = onSelect
+        _client = State(initialValue: OneDriveClient(accessToken: accessToken))
+    }
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            OneDriveFolderContentView(client: client, folder: rootFolder, onSelect: onSelect)
+                .navigationDestination(for: OneDriveItem.self) { folder in
+                    OneDriveFolderContentView(
+                        client: client,
+                        folder: folder,
+                        onSelect: onSelect
+                    )
+                }
+        }
+    }
+}
+
+// MARK: - Subview: Folder content
+
+private struct OneDriveFolderContentView: View {
+    let client: OneDriveClient
+    let folder: OneDriveItem
+    let onSelect: (String, String) -> Void
+
+    @State private var isLoading = false
+    @State private var entries: [OneDriveItem] = []
+    @State private var errorMessage: String?
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Group {
+            if isLoading && entries.isEmpty {
+                VStack(spacing: 6) {
+                    ProgressView()
+                    Text("LOADING")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            } else if let errorMessage, entries.isEmpty {
+                VStack(spacing: 12) {
+                    Image(systemName: "exclamationmark.triangle")
+                    Text(errorMessage).multilineTextAlignment(.center)
+                    Button("Retry") { Task { await load() } }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                .padding()
+            } else if entries.isEmpty {
+                VStack {
+                    Text("No Items")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            } else {
+                List {
+                    ForEach(entries) { item in
+                        if item.isFolder {
+                            NavigationLink(value: item) {
+                                HStack(spacing: 12) {
+                                    Image(systemName: "folder.fill")
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(width: 32, height: 32)
+                                        .foregroundStyle(.blue)
+                                    VStack(alignment: .leading) {
+                                        Text(item.name)
+                                            .lineLimit(1)
+                                            .foregroundStyle(.primary)
+                                        if let modifiedTime = item.modifiedTime {
+                                            Text(modifiedTime.smartString())
+                                                .font(.footnote)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                }
+                                .contentShape(Rectangle())
+                            }
+                        } else {
+                            HStack(spacing: 12) {
+                                Image(systemName: "document")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 32, height: 32)
+                                    .foregroundStyle(.tertiary)
+                                VStack(alignment: .leading) {
+                                    Text(item.name)
+                                        .lineLimit(1)
+                                        .foregroundStyle(.secondary)
+                                    if let modifiedTime = item.modifiedTime {
+                                        Text(modifiedTime.smartString())
+                                            .font(.footnote)
+                                            .foregroundStyle(.tertiary)
+                                    }
+                                }
+                            }
+                            .contentShape(Rectangle())
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(folder.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .listStyle(.inset)
+        .toolbar {
+            ToolbarItem(id: "open-toolbar-item", placement: .topBarTrailing) {
+                Button("Open", role: canSelect ? .confirm : nil) {
+                    var libraryName = folder.name
+                    if libraryName.hasSuffix(".library") {
+                        libraryName = String(libraryName.dropLast(".library".count))
+                    }
+                    onSelect(libraryName, folder.id)
+                    dismiss()
+                }
+                .disabled(!canSelect)
+            }
+        }
+        .task { await load() }
+    }
+
+    private var canSelect: Bool {
+        folder.name.hasSuffix(".library")
+    }
+
+    private func load() async {
+        if isLoading { return }
+        isLoading = true
+        errorMessage = nil
+        do {
+            let list = try await client.listChildren(of: folder.id)
+            await MainActor.run {
+                self.entries = list
+            }
+        } catch {
+            await MainActor.run {
+                self.errorMessage = (error as NSError).localizedDescription
+                self.entries = []
+            }
+        }
+        await MainActor.run { self.isLoading = false }
+    }
+}


### PR DESCRIPTION
Hi! First off, thank you so much for this project and for releasing it under CC0. Eagle Viewer is genuinely one of the best ways to browse Eagle libraries on iOS, and the codebase is really clean and well-structured. I've been using it daily.

## What this is

I saw that your Google Drive integration is still in progress (PR #29), but I needed cloud library support pretty urgently -- specifically OneDrive, since that's where my Eagle libraries live. So I went ahead and built it out on top of your `feature/google-drive` branch.

This PR adds **read-only OneDrive support** with on-demand image loading. The implementation follows your existing Google Drive patterns as closely as possible.

## What's included

### Commit 1: OneDrive auth and browsing (`86b45ec`)

- OAuth 2.0 + PKCE authentication via `ASWebAuthenticationSession` (no extra dependencies)
- `OneDriveAuthManager` -- handles token acquisition, refresh, and persistence in Keychain
- `OneDriveSourceEntity` implementing the existing `SourceEntity` protocol via Microsoft Graph API
- `OneDriveFolderPickerView` -- folder browser mirroring the Google Drive picker UI
- `LibrarySource.onedrive` case with full Codable support
- OneDrive button added to folder select, settings, and first launch views
- Client ID is a placeholder (`YOUR_ONEDRIVE_CLIENT_ID`) in Info.plist -- you'd need to register your own Azure AD app

### Commit 2: On-demand loading and bug fixes (`e5313b4`)

After testing with real libraries on OneDrive, I ran into several issues that needed fixing:

- **Rate limiting**: OneDrive's API throttles aggressively. Added `OneDriveRequestLimiter` (2 concurrent requests + 200ms inter-request delay) to avoid HTTP 429 floods
- **On-demand image downloads**: `OneDriveImageDownloader` actor that lazily downloads thumbnails/images only when they scroll into view, with in-flight deduplication
- **Thumbnail view updates**: Modified `ItemThumbnailView`, `ItemImageView`, and `ItemVideoView` to trigger on-demand downloads for OneDrive sources
- **Folder cover thumbnails**: Rewrote `FolderThumbnailViewWithCache` with a separate OneDrive code path using `@State`-driven re-rendering (bypassing `CacheManager` which assumes local files)
- **Perpetual loading fix**: Folder covers got stuck in loading state when the `folderItem` junction table had no entries for a folder. Now checks `MetadataImportManager.isImporting` and shows empty state when import is done
- **JSON decode resilience**: `MetadataImporter.decodeJSONResilient` handles metadata.json files with trailing garbage bytes (common in some Eagle libraries)
- **Source ordering bug**: `LibraryFolderManager.currentLibrarySource` was getting cleared by `discardAccess()` -- fixed by setting it after the discard

### Note on Eagle version requirement

I lowered the Eagle library version check from `>= 4.0.0` to `>= 2.0.0` because I have quite a few libraries created with Eagle 2.x and 3.x, and I couldn't find a way to upgrade the library format within Eagle itself. The related manifest changes reflect this. Everything has been working fine in my testing with older libraries, but this is worth noting in case you'd prefer to keep the stricter version check -- happy to revert this part if needed.

## Setup notes

To test this, you'll need to:
1. Register an app in [Azure AD](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) with `Files.Read` + `Files.Read.All` permissions and a mobile redirect URI (see step-by-step guide in the collapsible section at the bottom)
2. Put the client ID in `Info.plist` under `OneDriveClientID`

## Going forward

Totally understand if you're not ready to merge this -- your Google Drive work is still in progress and you might want to land that first. No pressure at all. If it sits for a while, I'll probably maintain a fork since a few friends also want to use it with OneDrive. But ideally it'd be nice to have everything upstream.

Happy to adjust anything if you have feedback on the approach.

---

<details>
<summary>Technical notes from testing</summary>

### OneDrive API quirks

- Microsoft Graph API returns `@microsoft.graph.downloadUrl` for file content, which is a pre-authenticated URL that expires. Token refresh needs to handle 401s gracefully.
- Rate limiting (HTTP 429) kicks in fast with concurrent requests. The original 6-concurrent limit caused 254+ throttle responses. Settled on 2 concurrent + 200ms delay as a safe default.
- PKCE is required for mobile apps since they can't securely store a client secret.

### Eagle library format observations

- Some Eagle libraries have items whose `metadata.json` lacks the `folders` array entirely. This means the `folderItem` junction table ends up empty for those libraries, even though folders exist in the top-level `metadata.json`. The app now handles this gracefully instead of showing infinite loading spinners.
- Some `metadata.json` files have trailing garbage bytes after the valid JSON. The resilient decoder handles this by finding the JSON boundary on decode failure.

### Architecture decisions

- Used `ASWebAuthenticationSession` instead of MSAL SDK to stay dependency-free (matching the Google Drive approach which uses the lightweight Google Sign-In SDK)
- `OneDriveImageDownloader` is an actor with `inFlight` task deduplication -- multiple views requesting the same image won't trigger duplicate downloads
- The folder cover thumbnail view has two completely separate code paths: CacheManager for local/Google Drive, and @State-driven for OneDrive. This avoids the race condition where CacheManager caches `.empty` before import completes.

</details>

<details>
<summary>Azure AD app registration step-by-step</summary>

Here's a detailed walkthrough for setting up the Azure AD app so OneDrive auth works:

### 1. Create the app registration

1. Go to [Azure Portal → App registrations](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)
2. Click **"New registration"** at the top
3. Fill in:
   - **Name**: something like `Eagle Viewer` (this is just a display name)
   - **Supported account types**: select **"Personal Microsoft accounts only"** (third option) — this covers regular OneDrive users. If you also want org accounts, pick "Accounts in any organizational directory and personal Microsoft accounts"
   - **Redirect URI**: select **"Mobile and desktop applications"** from the dropdown, and set the URI to: `msauth.com.naamiru.EagleViewer://auth`
4. Click **"Register"**

### 2. Note your Client ID

1. After registration, you'll land on the app's **Overview** page
2. Copy the **"Application (client) ID"** — this is what goes into `Info.plist` under `OneDriveClientID`

### 3. Add API permissions

1. In the left sidebar, click **"API permissions"**
2. Click **"Add a permission"**
3. Select **"Microsoft Graph"**
4. Select **"Delegated permissions"**
5. Search for and check these two permissions:
   - `Files.Read` — read user's files
   - `Files.Read.All` — read all files the user can access (needed for shared/root-level browsing)
6. Click **"Add permissions"**
7. You should now see `Files.Read` and `Files.Read.All` listed under Microsoft Graph (along with the default `User.Read`)
8. Admin consent is **not required** for personal accounts

### 4. Configure the redirect URI (verify)

1. In the left sidebar, click **"Authentication"**
2. Under **"Mobile and desktop applications"**, make sure your redirect URI is listed: `msauth.com.naamiru.EagleViewer://auth`
3. If it's not there, click **"Add a platform"** → **"Mobile and desktop applications"** → enter the URI
4. Make sure **"Access tokens"** and **"ID tokens"** are checked under "Implicit grant and hybrid flows" (these aren't strictly needed for PKCE, but some configs expect them)

### 5. Update Info.plist

1. Open `Info.plist` in Xcode
2. Set `OneDriveClientID` to the Application (client) ID you copied
3. Make sure the URL scheme `msauth.com.naamiru.EagleViewer` is registered under `CFBundleURLSchemes` so the auth callback works

That's it — build and run, and the OneDrive sign-in flow should work.

</details>

